### PR TITLE
Fix exported files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,8 +8,8 @@
 /.*                 export-ignore
 CHANGELOG.md        export-ignore
 Gruntfile.js        export-ignore
+README.md           export-ignore
 package.json        export-ignore
 package-lock.json   export-ignore
 phpcs.xml           export-ignore
-README.md           export-ignore
 renovate.json       export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,3 @@ Thumbs.db
 # Build & Releases
 /build/
 /releases/
-
-# Various file types to ignore when exporting.
-.gitconfig
-*.json
-*.yml
-*.sh


### PR DESCRIPTION
Exported file (`git archive`, GitHub ZIP, Packagist) are git index-based, not filesystem-based, and controlled by `.gitattributes`.

And reordered `.gitattributes`
